### PR TITLE
Add product philosophy and implementation guidance docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # Repository Guidelines
 
+## Required Reading
+
+Before working on this codebase, read these companion documents:
+
+- **[PHILOSOPHY.md](./PHILOSOPHY.md)** — Product vision, design principles, and what we are (and aren't) building
+- **[IMPLEMENTATION.md](./IMPLEMENTATION.md)** — Technical opinions, code conventions, and guidance for adding features
+
 ## Project Structure & Module Organization
 This monorepo uses `pnpm` workspaces. Runtime workers live in `apps/streamling-state` (Durable Object core) and `apps/twitch-eventsub` (EventSub adapter). The SvelteKit dashboard is in `apps/web`. Shared types and utilities belong in `packages/shared`. Keep integration assets, scripts, and wrangler configs within their respective app directories to avoid cross-app coupling.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Required Reading
+
+Before working on this codebase, read these companion documents:
+
+- **[PHILOSOPHY.md](./PHILOSOPHY.md)** — Product vision, design principles, and what we are (and aren't) building
+- **[IMPLEMENTATION.md](./IMPLEMENTATION.md)** — Technical opinions, code conventions, and guidance for adding features
+
 ## Project Overview
 
 Streamlings is a multi-platform interactive pet that lives on stream and responds to chat - like a Tamagotchi powered by your audience. The project uses a pnpm workspace monorepo with a multi-worker architecture that supports multiple streaming platforms.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,0 +1,100 @@
+# Implementation Guidance
+
+Technical opinions and conventions for working in the Streamlings codebase. These are decisions we've made — follow them for consistency.
+
+## Architecture Opinions
+
+### Durable Objects Are the Source of Truth
+
+All Streamling state lives in the Durable Object. The D1 database in the web app is for user/account data, not for Streamling runtime state. Don't duplicate state between the two — the web app should read Streamling state by calling the worker's `/telemetry` endpoint, not by maintaining a parallel copy.
+
+### Adapters Are Thin
+
+Platform adapters (like `twitch-eventsub`) should do three things: verify the incoming webhook, extract a normalized event, and forward it. No business logic, no state, no configuration. If you're writing an `if` statement about mood or energy in an adapter, it belongs in `streamling-state` instead.
+
+### Shared Types Are the Contract
+
+The `packages/shared` types define the boundary between systems. When adding a new event type or changing the telemetry shape, update the shared types first, then update the producers and consumers. Don't use `any` or inline type definitions to bypass the shared contract.
+
+### Workers Over Traditional Servers
+
+We deploy on Cloudflare. Workers and Durable Objects are the compute model. Don't introduce patterns that assume long-lived server processes, in-memory caches that survive requests, or filesystem access. Everything persists through Durable Object storage or D1.
+
+## Code Conventions
+
+### TypeScript
+
+- Strict mode, no `any` at module boundaries (internal `any` for Cloudflare SDK quirks is acceptable with a comment)
+- Prefer `interface` over `type` for object shapes that might be extended
+- Use the shared types package — don't redeclare types locally
+- Enum values are lowercase strings (`'sleeping'`, not `'SLEEPING'` or `0`)
+
+### State Management
+
+- All state mutations in the Durable Object go through named methods (`incrementEvent`, `updateConfig`), not direct storage writes from the HTTP handler
+- Persist state immediately after mutation — don't batch or defer writes
+- Use `blockConcurrencyWhile` for initialization, not for regular operations
+
+### Energy and Mood System
+
+- The energy system uses EMA (exponential moving average) for smoothing. Don't replace this with simple averages or windowed means — the EMA's decay properties are load-bearing for the feel of the system
+- The mood state machine uses hysteresis (hold times). Every transition requires sustained conditions, not instantaneous threshold crossings. This is intentional and should not be "optimized" away
+- Internal drives (sleep pressure, exhaustion, etc.) exist to create autonomous behavior independent of chat activity. They make the Streamling feel alive during quiet periods. Preserve their influence in any mood system changes
+- Default configuration values are tuned for real stream conditions. Change them with care and test with simulated event streams
+
+### Testing
+
+- Worker tests use Wrangler's `unstable_dev` to run against real Durable Objects. Don't mock the Durable Object layer — the integration test is the point
+- Energy and mood unit tests verify mathematical properties (EMA convergence, state transition correctness). Keep these fast and deterministic by using fixed timestamps
+- New event types need both a unit test (does the counter increment?) and a check that the activity category mapping is correct (message vs. high-value)
+- Web app tests are currently minimal. New UI features should include Vitest component tests at minimum
+
+### Frontend (SvelteKit)
+
+- Svelte 5 with runes — use `$state`, `$derived`, `$effect` instead of Svelte 4 stores
+- TailwindCSS v4 for styling — no CSS modules, no styled-components, no inline style objects
+- Use SvelteKit's `+page.server.ts` for data loading, not client-side fetches in `onMount`
+- Clerk handles auth — don't build custom auth flows
+
+### Database (Drizzle + D1)
+
+- Schema lives in `apps/web/src/lib/server/db/schema.js`
+- Use Drizzle's query builder, not raw SQL
+- Migrations via `pnpm db:generate` and `pnpm db:migrate` — don't manually write migration files
+- D1 in production, libSQL locally — the client initialization in `db/index.js` handles this split
+
+## Adding New Features
+
+### Adding a New Platform Adapter
+
+1. Create a new app in `apps/` (e.g., `apps/youtube-adapter`)
+2. Handle webhook verification per the platform's spec
+3. Extract user ID and event type from the platform payload
+4. Map the event to one of the existing activity categories (message, high-value) or propose a new category in the shared types
+5. Forward to `streamling-state` via its `/webhook` endpoint
+6. Add wrangler.toml with `STREAMLING_STATE_URL` binding
+7. Add the adapter to the CI deploy pipeline
+
+### Adding a New Mood State
+
+1. Add the state to `MoodState` enum in `packages/shared/types.ts`
+2. Define transitions to/from adjacent states in `mood.ts`
+3. Add threshold and hold time config to `MoodTransitionConfig`
+4. Update `getNextState` to include the new state in the transition graph
+5. Add tests for every new transition path
+6. Update default config values with tuned thresholds
+
+### Adding a New Event Type
+
+1. Add the event type string to `EVENT_CATEGORIES` in `streamling-state/src/index.ts`
+2. If it's a new category (not message or high-value), add a new weight to `EnergyConfig` and update `calculateRawActivity`
+3. Update the shared types if the event payload shape needs to be typed
+4. Add the event type to the adapter that produces it
+5. Test with `pnpm test:event` or a custom script
+
+## Performance Considerations
+
+- Durable Object alarms tick every 10 seconds. This is the resolution of the energy/mood system. Don't reduce the tick rate below 5 seconds — the EMA alphas are tuned for the current rate
+- Activity history is bounded by `stdDevWindowSize` (default 60 samples = 10 minutes). This prevents unbounded memory growth
+- Event counts are persisted on every event. If this becomes a bottleneck at scale, consider batching writes within a tick window, but measure first
+- The web app should poll `/telemetry` at a reasonable interval (every few seconds), not on every render frame. Use SSE or WebSockets if real-time updates become a requirement

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -1,0 +1,70 @@
+# Product Philosophy
+
+This document captures the product vision and design principles behind Streamlings. It should guide feature decisions, prioritization, and how we think about the experience.
+
+## Core Concept
+
+A Streamling is a digital creature that lives on a streamer's broadcast and reflects the energy of the community in real time. It is not a chatbot, not a widget, and not a dashboard metric. It is a pet — something the audience cares about, bonds with, and influences through their collective behavior.
+
+## Design Principles
+
+### 1. The Streamling Is Alive, Not a Meter
+
+The Streamling should feel like a living thing, not a data visualization. Its mood transitions should feel natural and organic — waking up slowly, getting excited gradually, crashing after a long party. Avoid anything that makes it feel like a progress bar or a KPI gauge.
+
+The energy and mood systems exist to create believable behavior, not to report numbers. Internal drives (sleep pressure, exhaustion, curiosity) exist specifically to prevent the Streamling from feeling like a simple input-output function.
+
+### 2. The Community Is the Player
+
+The audience collectively "plays" the Streamling through their natural behavior — chatting, subscribing, cheering. No one person controls it. The interesting emergent behavior comes from the crowd acting as a whole, and the Streamling's delayed, smoothed responses to that activity.
+
+Avoid features that give individual users direct control over the Streamling's state. The magic is in the indirect influence.
+
+### 3. Slow Over Fast
+
+Hysteresis is a feature, not a limitation. The hold times, EMA smoothing, and minimum durations exist so the Streamling doesn't flicker between states. A 90-second hold before transitioning from Idle to Engaged means the chat has to sustain energy, not just spike once.
+
+When in doubt, make transitions slower rather than faster. A Streamling that takes time to wake up and wind down feels more alive than one that snaps between states.
+
+### 4. Platform Agnostic at the Core
+
+The state engine knows nothing about Twitch, YouTube, or any specific platform. It receives normalized activity metrics and produces mood state. Platform adapters are thin translation layers that map platform-specific events into the shared activity model.
+
+This is non-negotiable for the architecture. Any platform-specific logic belongs in an adapter, never in the core state engine.
+
+### 5. Streamer Ownership
+
+The Streamling belongs to the streamer. They should be able to tune its personality — how excitable it is, how quickly it falls asleep, how long it can party before getting exhausted. The configuration system exists to make every Streamling unique to its community.
+
+Defaults should work well out of the box. Tuning should be optional, not required.
+
+### 6. Observable, Not Overwhelming
+
+Streamers and their communities should be able to understand what the Streamling is doing and roughly why. Telemetry exists for transparency, not complexity. The dashboard should answer "what is it doing?" and "why?" — not present a wall of charts.
+
+### 7. Delightful, Not Distracting
+
+On stream, the Streamling should enhance the experience without competing for attention. It should be a companion in the corner, not a flashing alert system. Visual design should prioritize charm and subtlety over spectacle.
+
+## Product Direction
+
+### What We're Building Toward
+
+- A visual creature on stream that audiences genuinely care about
+- A dashboard where streamers can understand and tune their Streamling's behavior
+- A stream overlay (OBS browser source) that renders the Streamling
+- Multi-platform support so the same Streamling responds to activity from Twitch, YouTube, and beyond
+
+### What We're Not Building
+
+- A chatbot or command responder
+- A stream analytics dashboard
+- A gamification or loyalty points system
+- A notification/alert widget
+
+### Open Questions
+
+- How should the Streamling behave between streams (offline state)?
+- Should the Streamling have visual customization (skins, accessories)?
+- How do we handle multi-platform streams where activity comes from multiple adapters simultaneously?
+- Should there be any direct interaction (e.g., channel point redemptions that "pet" the Streamling)?


### PR DESCRIPTION
Create PHILOSOPHY.md (product vision, design principles, what we are/aren't
building) and IMPLEMENTATION.md (technical opinions, code conventions, feature
addition guides). Link both as required reading in CLAUDE.md and AGENTS.md.

https://claude.ai/code/session_01Xr4ge8ceGxqtrBxUBdaZr1