### PR TITLE
fix: force 3D component recreation when switching character types

### DIFF
--- a/apps/web/src/routes/(overlay)/overlay/[id]/+page.svelte
+++ b/apps/web/src/routes/(overlay)/overlay/[id]/+page.svelte
@@ -20,11 +20,16 @@
 				? '/models/default.glb'
 				: null
 	);
+	const activeAnimationUrls = $derived(
+		data.characterType === 'custom' ? data.animationUrls : null
+	);
 </script>
 
 <div class="overlay-root">
 	{#if activeModelUrl}
-		<StreamlingOverlay3D {mood} modelUrl={activeModelUrl} animationUrls={data.animationUrls} />
+		{#key activeModelUrl}
+			<StreamlingOverlay3D {mood} modelUrl={activeModelUrl} animationUrls={activeAnimationUrls} />
+		{/key}
 	{:else}
 		<StreamlingOverlay {mood} />
 	{/if}

--- a/apps/web/src/routes/(overlay)/overlay/[id]/+page.svelte
+++ b/apps/web/src/routes/(overlay)/overlay/[id]/+page.svelte
@@ -20,9 +20,7 @@
 				? '/models/default.glb'
 				: null
 	);
-	const activeAnimationUrls = $derived(
-		data.characterType === 'custom' ? data.animationUrls : null
-	);
+	const activeAnimationUrls = $derived(data.characterType === 'custom' ? data.animationUrls : null);
 </script>
 
 <div class="overlay-root">

--- a/apps/web/src/routes/dashboard/+page.svelte
+++ b/apps/web/src/routes/dashboard/+page.svelte
@@ -43,9 +43,7 @@
 				? '/models/default.glb'
 				: null
 	);
-	const activeAnimationUrls = $derived(
-		data.characterType === 'custom' ? data.animationUrls : null
-	);
+	const activeAnimationUrls = $derived(data.characterType === 'custom' ? data.animationUrls : null);
 </script>
 
 <div class="min-h-screen bg-gray-50">

--- a/apps/web/src/routes/dashboard/+page.svelte
+++ b/apps/web/src/routes/dashboard/+page.svelte
@@ -43,6 +43,9 @@
 				? '/models/default.glb'
 				: null
 	);
+	const activeAnimationUrls = $derived(
+		data.characterType === 'custom' ? data.animationUrls : null
+	);
 </script>
 
 <div class="min-h-screen bg-gray-50">
@@ -90,11 +93,13 @@
 
 		<div class="mb-6 flex justify-center rounded-lg bg-white p-8 shadow">
 			{#if activeModelUrl}
-				<StreamlingOverlay3D
-					mood={effectiveMood}
-					modelUrl={activeModelUrl}
-					animationUrls={data.animationUrls}
-				/>
+				{#key activeModelUrl}
+					<StreamlingOverlay3D
+						mood={effectiveMood}
+						modelUrl={activeModelUrl}
+						animationUrls={activeAnimationUrls}
+					/>
+				{/key}
 			{:else}
 				<StreamlingOverlay mood={effectiveMood} />
 			{/if}


### PR DESCRIPTION
## Summary
- Switching between "3D Default" and "Custom" didn't load the new model because `StreamlingOverlay3D` loads the GLB in `onMount` (only runs once)
- Wrap component in `{#key activeModelUrl}` to destroy/recreate when the URL changes
- Only pass `animationUrls` for custom character type (not for default-3d which has no animations)

## Test plan
- [ ] Select "3D Default" → model loads
- [ ] Switch to "Custom" → custom model replaces default
- [ ] Switch back to "3D Default" → default model replaces custom
- [ ] Switch to "Plant" → 2D overlay renders
- [ ] Switch from "Plant" to any 3D → 3D component renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)