### PR TITLE
feat: expand animation library with 7 mood-specific animations

### DIFF
--- a/apps/web/src/lib/components/StreamlingCustomize.svelte
+++ b/apps/web/src/lib/components/StreamlingCustomize.svelte
@@ -123,7 +123,7 @@
 					style="width: {progress}%"
 				></div>
 			</div>
-			<p class="text-xs text-gray-500">This usually takes 3-5 minutes</p>
+			<p class="text-xs text-gray-500">This usually takes 5-10 minutes</p>
 		</div>
 	{:else if errorMessage}
 		<!-- Error state -->

--- a/apps/web/src/lib/components/StreamlingOverlay3D.svelte
+++ b/apps/web/src/lib/components/StreamlingOverlay3D.svelte
@@ -72,21 +72,24 @@
 		let activeAction = null;
 		let useSkeletal = false;
 
-		/** Mood name → animation clip key */
-		const MOOD_ANIM_MAP = /** @type {Record<string, string>} */ ({
-			sleeping: 'idle',
-			idle: 'idle',
-			engaged: 'walking',
-			partying: 'dancing'
+		/** Mood name → candidate animation clip keys (random pick) */
+		const MOOD_ANIM_MAP = /** @type {Record<string, string[]>} */ ({
+			sleeping: ['dozing'],
+			idle: ['idle'],
+			engaged: ['walking', 'happy_jump'],
+			partying: ['dancing_01', 'dancing_02', 'gangnam', 'boom_dance']
 		});
 
 		/** Mood name → animation timeScale */
 		const MOOD_SPEED_MAP = /** @type {Record<string, number>} */ ({
-			sleeping: 0.3,
+			sleeping: 0.7,
 			idle: 1.0,
 			engaged: 1.0,
 			partying: 1.0
 		});
+
+		/** Track last picked animation key to avoid repeats */
+		let lastPickedKey = '';
 
 		const loader = new GLTFLoader();
 
@@ -171,14 +174,41 @@
 		}
 
 		/**
-		 * Crossfade to the animation clip for the given mood.
+		 * Crossfade to a random available animation clip for the given mood.
 		 * @param {string} moodName
 		 */
 		function switchAnimation(moodName) {
-			const clipKey = MOOD_ANIM_MAP[moodName] ?? 'idle';
-			const newAction = actions[clipKey];
-			if (!newAction || newAction === activeAction) {
-				// Just update speed if same action
+			const candidates = MOOD_ANIM_MAP[moodName] ?? ['idle'];
+			// Filter to only clips that were actually loaded
+			const available = candidates.filter((key) => actions[key]);
+
+			if (available.length === 0) {
+				// Fallback to idle if none of the mood's clips loaded
+				if (actions['idle'] && actions['idle'] !== activeAction) {
+					const fallback = actions['idle'];
+					fallback.timeScale = MOOD_SPEED_MAP[moodName] ?? 1.0;
+					if (activeAction) {
+						fallback.reset();
+						fallback.play();
+						activeAction.crossFadeTo(fallback, 0.5, true);
+					} else {
+						fallback.play();
+					}
+					activeAction = fallback;
+				}
+				return;
+			}
+
+			// Pick a random clip, avoiding the same one twice in a row
+			let pick = available[Math.floor(Math.random() * available.length)];
+			if (available.length > 1 && pick === lastPickedKey) {
+				const others = available.filter((k) => k !== lastPickedKey);
+				pick = others[Math.floor(Math.random() * others.length)];
+			}
+			lastPickedKey = pick;
+
+			const newAction = actions[pick];
+			if (newAction === activeAction) {
 				if (activeAction) {
 					activeAction.timeScale = MOOD_SPEED_MAP[moodName] ?? 1.0;
 				}

--- a/apps/web/src/lib/server/meshy.js
+++ b/apps/web/src/lib/server/meshy.js
@@ -202,8 +202,24 @@ export async function getRiggingTask(apiKey, taskId) {
 /** Well-known animation action IDs from the Meshy animation library. */
 export const ANIMATION_IDS = {
 	idle: 0,
-	dancing: 22
+	dozing: 38,
+	happy_jump: 44,
+	dancing_01: 22,
+	dancing_02: 23,
+	gangnam: 74,
+	boom_dance: 66
 };
+
+/** Ordered sequence of animations to request in the generation pipeline. */
+export const ANIMATION_SEQUENCE = [
+	{ key: 'dozing', actionId: 38 },
+	{ key: 'idle', actionId: 0 },
+	{ key: 'happy_jump', actionId: 44 },
+	{ key: 'dancing_01', actionId: 22 },
+	{ key: 'dancing_02', actionId: 23 },
+	{ key: 'gangnam', actionId: 74 },
+	{ key: 'boom_dance', actionId: 66 }
+];
 
 /**
  * @typedef {object} AnimationResult

--- a/apps/web/src/routes/api/streamling/generate/status/+server.js
+++ b/apps/web/src/routes/api/streamling/generate/status/+server.js
@@ -19,7 +19,7 @@ import {
 	getRiggingTask,
 	createAnimationTask,
 	getAnimationTask,
-	ANIMATION_IDS
+	ANIMATION_SEQUENCE
 } from '$lib/server/meshy.js';
 
 /**
@@ -197,11 +197,12 @@ async function handleRigging(db, apiKey, record, platform) {
 			'running'
 		);
 
-		// Start idle animation
+		// Start first animation from sequence
+		const firstAnim = ANIMATION_SEQUENCE[0];
 		const { taskId: animTaskId } = await createAnimationTask(
 			apiKey,
 			record.meshyRigTaskId ?? record.meshyTaskId,
-			ANIMATION_IDS.idle
+			firstAnim.actionId
 		);
 
 		/** @type {Record<string, string>} */
@@ -236,7 +237,7 @@ async function handleRigging(db, apiKey, record, platform) {
 }
 
 /**
- * Handle the animating stage: poll animation task, advance through idle → dancing → ready.
+ * Handle the animating stage: poll animation task, advance through ANIMATION_SEQUENCE → ready.
  * @param {any} db
  * @param {string} apiKey
  * @param {any} record
@@ -253,21 +254,33 @@ async function handleAnimating(db, apiKey, record, platform) {
 		/** @type {Record<string, string>} */
 		const animUrls = record.animationUrls ? JSON.parse(record.animationUrls) : {};
 
-		if (!animUrls.idle) {
-			// Just completed the idle animation — store it and request dancing
-			const idleUrl = await storeGlb(platform, record.id, task.result.animation_glb_url, 'idle');
-			animUrls.idle = idleUrl;
+		// Find which animation just completed (the first one not yet in animUrls)
+		const justCompleted = ANIMATION_SEQUENCE.find((a) => !animUrls[a.key]);
+		if (justCompleted) {
+			const storedUrl = await storeGlb(
+				platform,
+				record.id,
+				task.result.animation_glb_url,
+				justCompleted.key
+			);
+			animUrls[justCompleted.key] = storedUrl;
+		}
 
-			const { taskId: danceTaskId } = await createAnimationTask(
+		// Find the next animation to request
+		const nextAnim = ANIMATION_SEQUENCE.find((a) => !animUrls[a.key]);
+
+		if (nextAnim) {
+			// Request next animation
+			const { taskId } = await createAnimationTask(
 				apiKey,
 				record.meshyRigTaskId,
-				ANIMATION_IDS.dancing
+				nextAnim.actionId
 			);
 
 			await db
 				.update(streamling)
 				.set({
-					meshyTaskId: danceTaskId,
+					meshyTaskId: taskId,
 					animationUrls: JSON.stringify(animUrls)
 				})
 				.where(eq(streamling.id, record.id))
@@ -281,15 +294,7 @@ async function handleAnimating(db, apiKey, record, platform) {
 			});
 		}
 
-		// Just completed the dancing animation — all done!
-		const dancingUrl = await storeGlb(
-			platform,
-			record.id,
-			task.result.animation_glb_url,
-			'dancing'
-		);
-		animUrls.dancing = dancingUrl;
-
+		// All animations complete
 		await db
 			.update(streamling)
 			.set({


### PR DESCRIPTION
## Summary
- Expand Meshy animation set from 2 to 7 curated clips (dozing, idle, happy_jump, dancing_01, dancing_02, gangnam, boom_dance) for richer mood-driven behavior
- Replace hardcoded idle→dancing pipeline with data-driven `ANIMATION_SEQUENCE` loop that automatically progresses through all animations
- Update `StreamlingOverlay3D` mood mapping to randomly pick from available clips per mood, with no-repeat logic for partying dances
- Update generation time estimate from 3-5 to 5-10 minutes

## Test plan
- [ ] `pnpm check` — 0 type errors
- [ ] `pnpm test:unit -- --run` — all 145 tests pass
- [ ] Regenerate custom streamling → verify pipeline progresses through all 7 animation stages
- [ ] Cycle through moods on dashboard: sleeping=dozing, idle=idle, engaged=walking/happy_jump, partying=random dances
- [ ] Re-enter partying mood multiple times → verify different dances picked

🤖 Generated with [Claude Code](https://claude.com/claude-code)