### PR TITLE
fix: reset rig and animation state on regenerate

### DIFF
--- a/apps/web/src/routes/api/streamling/generate/+server.js
+++ b/apps/web/src/routes/api/streamling/generate/+server.js
@@ -54,7 +54,9 @@ export async function POST({ locals, request, platform }) {
 			meshyTaskId: taskId,
 			modelPrompt: prompt,
 			modelUrl: null,
-			modelRetries: 0
+			modelRetries: 0,
+			meshyRigTaskId: null,
+			animationUrls: null
 		})
 		.where(eq(streamling.id, record.id))
 		.run();


### PR DESCRIPTION
## Summary
- Clear `meshyRigTaskId` and `animationUrls` when starting a new generation
- Prevents stale animation data from previous generation interfering with the new 7-animation pipeline

## Test plan
- [ ] Regenerate an existing streamling → verify pipeline starts clean and progresses through all 7 animations
- [ ] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)